### PR TITLE
Allowed for use of galaxy profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN mkdir /import
 VOLUME ["/import/"]
 WORKDIR /import/
 
+RUN mkdir -p /.ipython/
+RUN ln -s /import/profile_galaxy/ /.ipython/profile_galaxy
+
 ADD ./startup.sh /startup.sh
 RUN chmod +x /startup.sh
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 /etc/init.d/cron start
-ipython notebook --no-browser --ip=0.0.0.0 --port 6789
+ipython notebook --no-browser --ip=0.0.0.0 --port 6789 --profile=galaxy


### PR DESCRIPTION
Created a symlink to the import directory, which means the galaxy profile will need to be fully
realised in the shared directory before the docker container may start.
