### PR TITLE
Use objects API

### DIFF
--- a/galaxy.py
+++ b/galaxy.py
@@ -2,16 +2,22 @@ from bioblend import galaxy
 from bioblend.galaxy.tools import ToolClient
 from bioblend.galaxy.histories import HistoryClient
 from bioblend.galaxy.datasets import DatasetClient
+from bioblend.galaxy import objects
 import yaml
 import subprocess
 import argparse
+
+# Consider not using objects deprecated.
+DEFAULT_USE_OBJECTS = True
+
 
 def _get_conf( config_file = '/import/conf.yaml' ):
     with open(config_file, 'rb') as handle:
         conf = yaml.load(handle)
     return conf
 
-def get_galaxy_connection( ):
+
+def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
     """
         Given access to the configuration dict that galaxy passed us, we try and connect to galaxy's API.
 
@@ -28,6 +34,7 @@ def get_galaxy_connection( ):
         the conditions of REMOTE_USER and galaxy running under uWSGI.
     """
     conf = _get_conf()
+    history_id = conf["history_id"]
     try:
         # Remove trailing slashes
         app_path = conf['galaxy_url'].rstrip('/')
@@ -53,42 +60,57 @@ def get_galaxy_connection( ):
             raise Exception("No port")
 
         built_galaxy_url = 'http://%s:%s/%s' %  (galaxy_ip.strip(), galaxy_port, app_path.strip())
-        gi = galaxy.GalaxyInstance(url=built_galaxy_url.rstrip('/'), key=conf['api_key'])
-        gi.histories.get_histories()
+        url = built_galaxy_url.rstrip('/')
+        key=conf['api_key']
+        if use_objects:
+            gi = objects.GalaxyInstance(url, key)
+            gi.histories.get(history_id)
+        else:
+            gi = galaxy.GalaxyInstance(url=url, key=key)
+            gi.histories.get_histories()
     except:
         try:
-            gi = galaxy.GalaxyInstance(url=conf['galaxy_url'], key=conf['api_key'])
-            gi.histories.get_histories()
-        except:
-            raise Exception("Could not connect to a galaxy instance. Please contact your SysAdmin for help with this error")
+            url=conf['galaxy_url']
+            key=conf['api_key']
+            if use_objects:
+                gi = objects.GalaxyInstance(url, key)
+                gi.histories.get(history_id)
+            else:
+                gi = galaxy.GalaxyInstance(url=url, key=key)
+                gi.histories.get_histories()
+        except Exception as e:
+            raise Exception("Could not connect to a galaxy instance. Please contact your SysAdmin for help with this error" + str(e))
     return gi
 
 def _get_history_id():
     conf = _get_conf()
     return conf['history_id']
 
-def put(filename, file_type = 'auto'):
+def put(filename, file_type = 'auto', use_objects=DEFAULT_USE_OBJECTS ):
     """
         Given a filename of any file accessible to the docker instance, this
         function will upload that file to galaxy using the current history.
         Does not return anything.
     """
     conf = _get_conf()
-    gi = get_galaxy_connection()
-    tc = ToolClient( gi )
-    tc.upload_file(filename, conf['history_id'], file_type = file_type)
+    gi = get_galaxy_connection(use_objects)
+    history_id = conf["history_id"]
+    if use_objects:
+        history = gi.histories.get(history_id)
+        history.upload_dataset( filename, file_type=file_type )
+    else:
+        tc = ToolClient( gi )
+        tc.upload_file(filename, history_id, file_type = file_type)
 
 
-def get( dataset_id ):
+def get( dataset_id, use_objects=DEFAULT_USE_OBJECTS ):
     """
         Given the history_id that is displayed to the user, this function will
         download the file from the history and stores it under /import/
         Return value is the path to the dataset stored under /import/
     """
     conf = _get_conf()
-    gi = get_galaxy_connection()
-    hc = HistoryClient( gi )
-    dc = DatasetClient( gi )
+    gi = get_galaxy_connection(use_objects)
 
     file_path = '/import/%s' % dataset_id
 
@@ -96,11 +118,21 @@ def get( dataset_id ):
     # silly like a get() for a Galaxy file in a for-loop, wouldn't want to
     # re-download every time and add that overhead.
     if not os.path.exists(file_path):
-        dataset_mapping = dict( [(dataset['hid'], dataset['id']) for dataset in hc.show_history(conf['history_id'], contents=True)] )
-        try:
-            hc.download_dataset(conf['history_id'], dataset_mapping[dataset_id], file_path, use_default_filename=False, to_ext=None)
-        except:
-            dc.download_dataset(dataset_mapping[dataset_id], file_path, use_default_filename=False)
+        history_id = conf["history_id"]
+
+        if use_objects:
+            history = gi.histories.get(history_id)
+            datasets = dict([(d.wrapped["hid"], d.id) for d in history.get_datasets()])
+            dataset = history.get_dataset(datasets[dataset_id])
+            dataset.download(open(file_path, 'wb'))
+        else:
+            hc = HistoryClient( gi )
+            dc = DatasetClient( gi )
+            dataset_mapping = dict( [(dataset['hid'], dataset['id']) for dataset in hc.show_history(history_id, contents=True)] )
+            try:
+                hc.download_dataset(history_id, dataset_mapping[dataset_id], file_path, use_default_filename=False, to_ext=None)
+            except:
+                dc.download_dataset(dataset_mapping[dataset_id], file_path, use_default_filename=False)
 
     return file_path
 


### PR DESCRIPTION
Its a higher-level, more correct interface. Especially for downloading - it actually correctly downloads against the API unlike the other end-points which target the web controllers and require the datasets to be public.

What do you guys think about heading in this direction?

http://www.ncbi.nlm.nih.gov/pubmed/24928211

The lower-level bioblend API still needs to be fixed to target the API - but I think exposing and targeting the higher-level API would be a good idea anyway.