### PR TITLE
Hardcode conf.yaml path

### DIFF
--- a/galaxy.py
+++ b/galaxy.py
@@ -6,7 +6,7 @@ import yaml
 import subprocess
 import argparse
 
-def _get_conf( config_file = 'conf.yaml' ):
+def _get_conf( config_file = '/import/conf.yaml' ):
     with open(config_file, 'rb') as handle:
         conf = yaml.load(handle)
     return conf


### PR DESCRIPTION
This was a problem I noticed in RStudio, where the cwd would affect finding of
conf.yaml. Thus, hardcoding that fixes our issue.
