### PR TITLE
Change default user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
     echo 'deb http://cran.r-project.org/bin/linux/ubuntu trusty/' >> /etc/apt/sources.list && \
     apt-get -qq update && apt-get install --no-install-recommends -y libcurl4-openssl-dev libxml2-dev \
     apt-transport-https python-dev libc-dev pandoc python-pip pkg-config liblzma-dev libbz2-dev libpcre3-dev \
-    build-essential libblas-dev liblapack-dev gfortran libzmq3-dev \
+    build-essential libblas-dev liblapack-dev gfortran libzmq3-dev curl \
     libfreetype6-dev libpng-dev net-tools procps r-base libreadline-dev && \
     pip install distribute --upgrade && \
     pip install pyzmq ipython==2.4 jinja2 tornado pygments numpy biopython scikit-learn pandas \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN mkdir /import /home/ipython
 
 # Create user and group with the same UID and GID as the Galaxy main docker container.
 RUN groupadd -r ipython -g 1450 && \
-    useradd -u 1450 -r -g ipython -d /home/ipython -c "IPython user" ipython && \
-    chown -R 1450:1450 /home/ipython /import
+    useradd -u 1450 -r -g ipython -d /home/ipython -c "IPython user" ipython
 
 # Install MathJax locally because it has some problems with https as reported here: https://github.com/bgruening/galaxy-ipython/pull/8
 RUN python -c 'from IPython.external import mathjax; mathjax.install_mathjax("2.5.0")'
@@ -55,6 +54,8 @@ ADD ./get /py/get
 # Make sure the system is aware that it can look for python code here
 ENV PYTHONPATH /py/:$PYTHONPATH
 ENV PATH /py/:$PATH
+
+RUN chown -R 1450:1450 /home/ipython /import
 
 # Drop privileges
 USER ipython


### PR DESCRIPTION
fix for: https://github.com/bgruening/docker-ipython-notebook/issues/28

This PR will change the default user to the same UID and GID of the parent Galaxy Docker container. This enables installing with `pip` and `install.package()`. Moreover, I added curl as dependency so we do not need to use a python library for this (we still can if we want).