### PR TITLE
Dyn host

### DIFF
--- a/galaxy.py
+++ b/galaxy.py
@@ -68,7 +68,12 @@ def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
     key = conf['api_key']
 
     ### Customised galaxy_url ###
-
+    galaxy_ip = _get_ip()
+    # Substitute $DOCKER_HOST with real IP
+    url = Template(conf['galaxy_url']).substitute({'DOCKER_HOST': galaxy_ip})
+    gi = _test_url(url, key, history_id, use_objects=use_objects)
+    if gi is not None:
+        return gi
 
     ### Raw galaxy_url ###
     url = conf['galaxy_url']
@@ -81,9 +86,6 @@ def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
     app_path = conf['galaxy_url'].rstrip('/')
     # Remove protocol+host:port if included
     app_path = ''.join(app_path.split('/')[3:])
-    # Now obtain IP address from a netstat command.
-    galaxy_ip = _get_ip()
-
 
     if 'galaxy_paster_port' not in conf:
         # We've failed to detect a port in the config we were given by

--- a/galaxy.py
+++ b/galaxy.py
@@ -67,16 +67,10 @@ def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
     history_id = conf["history_id"]
     key = conf['api_key']
 
-    ### Customised galaxy_url ###
+    ### Customised/Raw galaxy_url ###
     galaxy_ip = _get_ip()
     # Substitute $DOCKER_HOST with real IP
     url = Template(conf['galaxy_url']).substitute({'DOCKER_HOST': galaxy_ip})
-    gi = _test_url(url, key, history_id, use_objects=use_objects)
-    if gi is not None:
-        return gi
-
-    ### Raw galaxy_url ###
-    url = conf['galaxy_url']
     gi = _test_url(url, key, history_id, use_objects=use_objects)
     if gi is not None:
         return gi

--- a/galaxy.py
+++ b/galaxy.py
@@ -84,14 +84,15 @@ def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
     # Now obtain IP address from a netstat command.
     galaxy_ip = _get_ip()
 
-    # We should be able to find a port to connect to galaxy on via this
-    # conf var: galaxy_paster_port
-    galaxy_port = conf['galaxy_paster_port']
 
-    if not galaxy_port:
+    if 'galaxy_paster_port' not in conf:
         # We've failed to detect a port in the config we were given by
         # galaxy, so we won't be able to construct a valid URL
         raise Exception("No port")
+    else:
+        # We should be able to find a port to connect to galaxy on via this
+        # conf var: galaxy_paster_port
+        galaxy_port = conf['galaxy_paster_port']
 
     built_galaxy_url = 'http://%s:%s/%s' %  (galaxy_ip.strip(), galaxy_port, app_path.strip())
     url = built_galaxy_url.rstrip('/')


### PR DESCRIPTION
Major cleanup to `get_galaxy_connection` function.

New failover path, start with the passed `galaxy_url`, and try that. Failing that, substitute in `$DOCKER_HOST` if it's there Major cleanup to `get_galaxy_connection` function.

New failover path, start with the passed `galaxy_url`, and try that. If `$DOCKER_HOST` is in the variable, it'll be substituted in. Failing that, we pass to a completely custom-built URL, and then toss up an exception.