### PR TITLE
Improvements to galaxy.py

### DIFF
--- a/galaxy.py
+++ b/galaxy.py
@@ -12,7 +12,7 @@ logging.getLogger("bioblend").setLevel(logging.WARNING)
 DEBUG = os.environ.get('DEBUG', False) == 'True'
 if DEBUG:
     logging.basicConfig(level=logging.DEBUG)
-tlog = logging.getLogger()
+log = logging.getLogger()
 
 
 # Consider not using objects deprecated.

--- a/galaxy.py
+++ b/galaxy.py
@@ -114,14 +114,6 @@ def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
     raise Exception("Could not connect to a galaxy instance. Please contact your SysAdmin for help with this error")
 
 
-def _get_history_id():
-    """
-    Extract the history ID from the config file.
-    """
-    conf = _get_conf()
-    return conf['history_id']
-
-
 def put(filename, file_type='auto', history_id=None, use_objects=DEFAULT_USE_OBJECTS):
     """
         Given a filename of any file accessible to the docker instance, this
@@ -177,7 +169,8 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--filetype', help='Galaxy file format. If not specified Galaxy will try to guess the filetype automatically.', default='auto')
     args = parser.parse_args()
 
-    history_id = args.history_id or _get_history_id()
+    conf = _get_conf()
+    history_id = args.history_id or conf['history_id']
 
     if args.action == 'get':
         # Ensure it's a numerical value

--- a/galaxy.py
+++ b/galaxy.py
@@ -101,13 +101,13 @@ def get_galaxy_connection(history_id=None, use_objects=DEFAULT_USE_OBJECTS):
 
     ### Fail ###
     msg = "Could not connect to a galaxy instance. Please contact your SysAdmin for help with this error"
-    if os.environ['GALAXY_URL'] == '127.0.0.1':
+    if '127.0.0.1' in os.environ['GALAXY_URL']:
         msg += (
-            "\nWe see that you're running on localhost. "
-            "By binding to localhost, you prevent the docker "
+            "\nYou seem to be running galaxy on localhost. "
+            "By binding to 127.0.0.1, you prevent the docker "
             "based interactive environment from contacting the host, "
-            "as the host galaxy refuses to answer anything that "
-            "isn't from '127.0.0.1', like this docker container."
+            "as the host galaxy refuses to answer requests that "
+            "don't come from 127.0.0.1, like this docker container."
         )
     raise Exception(msg)
 

--- a/galaxy.py
+++ b/galaxy.py
@@ -129,6 +129,9 @@ def put(filename, file_type='auto', history_id=None, use_objects=DEFAULT_USE_OBJ
         function will upload that file to galaxy using the current history.
         Does not return anything.
     """
+    conf = _get_conf()
+    history_id = args.history_id or conf['history_id']
+
     gi = get_galaxy_connection(use_objects)
     if use_objects:
         history = gi.histories.get( history_id )
@@ -144,6 +147,9 @@ def get(dataset_id, history_id=None, use_objects=DEFAULT_USE_OBJECTS):
         download the file from the history and stores it under /import/
         Return value is the path to the dataset stored under /import/
     """
+    conf = _get_conf()
+    history_id = args.history_id or conf['history_id']
+
     gi = get_galaxy_connection(use_objects)
 
     file_path = '/import/%s' % dataset_id
@@ -177,9 +183,6 @@ if __name__ == '__main__':
         help='History ID. The history ID and the dataset ID uniquly identify a dataset. Per default this is set to the current Galaxy history.')
     parser.add_argument('-t', '--filetype', help='Galaxy file format. If not specified Galaxy will try to guess the filetype automatically.', default='auto')
     args = parser.parse_args()
-
-    conf = _get_conf()
-    history_id = args.history_id or conf['history_id']
 
     if args.action == 'get':
         # Ensure it's a numerical value

--- a/galaxy.py
+++ b/galaxy.py
@@ -111,7 +111,16 @@ def get_galaxy_connection( use_objects=DEFAULT_USE_OBJECTS ):
         return gi
 
     ### Fail ###
-    raise Exception("Could not connect to a galaxy instance. Please contact your SysAdmin for help with this error")
+    msg = "Could not connect to a galaxy instance. Please contact your SysAdmin for help with this error"
+    if conf['galaxy_url'] == '127.0.0.1':
+        msg += (
+            "\nWe see that you're running on localhost. "
+            "By binding to localhost, you prevent the docker "
+            "based interactive environment from contacting the host, "
+            "as the host galaxy refuses to answer anything that "
+            "isn't from '127.0.0.1', like this docker container."
+        )
+    raise Exception(msg)
 
 
 def put(filename, file_type='auto', history_id=None, use_objects=DEFAULT_USE_OBJECTS):

--- a/galaxy.py
+++ b/galaxy.py
@@ -12,7 +12,7 @@ logging.getLogger("bioblend").setLevel(logging.WARNING)
 DEBUG = os.environ.get('DEBUG', False) == 'True'
 if DEBUG:
     logging.basicConfig(level=logging.DEBUG)
-log = logging.getLogger()
+tlog = logging.getLogger()
 
 
 # Consider not using objects deprecated.
@@ -40,6 +40,7 @@ def _get_ip():
     cmd_awk = ['awk', '{ print $2 }']
     p3 = subprocess.Popen(cmd_awk, stdin=p2.stdout, stdout=subprocess.PIPE)
     galaxy_ip = p3.stdout.read()
+    log.debug('Host IP determined to be %s', galaxy_ip)
     return galaxy_ip
 
 
@@ -53,6 +54,7 @@ def _test_url(url, key, history_id, use_objects=False):
         else:
             gi = galaxy.GalaxyInstance(url=url, key=key)
             gi.histories.get_histories()
+        log.debug('Galaxy URL %s is functional', url)
         return gi
     except Exception:
         return None
@@ -126,9 +128,7 @@ def put(filename, file_type='auto', history_id=None, use_objects=DEFAULT_USE_OBJ
         function will upload that file to galaxy using the current history.
         Does not return anything.
     """
-    conf = _get_conf()
     gi = get_galaxy_connection(use_objects)
-    history_id = history_id or _get_history_id()
     if use_objects:
         history = gi.histories.get( history_id )
         history.upload_dataset(filename, file_type=file_type)
@@ -143,11 +143,9 @@ def get(dataset_id, history_id=None, use_objects=DEFAULT_USE_OBJECTS):
         download the file from the history and stores it under /import/
         Return value is the path to the dataset stored under /import/
     """
-    conf = _get_conf()
     gi = get_galaxy_connection(use_objects)
 
     file_path = '/import/%s' % dataset_id
-    history_id = history_id or _get_history_id()
 
     # Cache the file requests. E.g. in the example of someone doing something
     # silly like a get() for a Galaxy file in a for-loop, wouldn't want to
@@ -179,8 +177,10 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--filetype', help='Galaxy file format. If not specified Galaxy will try to guess the filetype automatically.', default='auto')
     args = parser.parse_args()
 
+    history_id = args.history_id or _get_history_id()
+
     if args.action == 'get':
         # Ensure it's a numerical value
-        get(int(args.argument))
+        get(int(args.argument), history_id=history_id)
     elif args.action == 'put':
-        put(args.argument, file_type=args.filetype)
+        put(args.argument, file_type=args.filetype, history_id=history_id)

--- a/galaxy.py
+++ b/galaxy.py
@@ -9,6 +9,11 @@ import os
 from string import Template
 import logging
 logging.getLogger("bioblend").setLevel(logging.WARNING)
+DEBUG = os.environ.get('DEBUG', False) == 'True'
+if DEBUG:
+    logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger()
+
 
 # Consider not using objects deprecated.
 DEFAULT_USE_OBJECTS = True

--- a/galaxy.py
+++ b/galaxy.py
@@ -8,10 +8,10 @@ import argparse
 import os
 from string import Template
 import logging
-logging.getLogger("bioblend").setLevel(logging.WARNING)
 DEBUG = os.environ.get('DEBUG', False) == 'True'
 if DEBUG:
     logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("bioblend").setLevel(logging.WARNING)
 log = logging.getLogger()
 
 


### PR DESCRIPTION
I booted up a new galaxy and found the UX of getting IEs unpleasant, so...

- enhanced error message if you're running on localhost, now it's obvious that you've bound galaxy to 127.0.0.1 and it isn't going to answer docker questions.

Enhanced dev experience:

- `export`ing `DEBUG=True` (or `true) now sets the logging level in galaxy.py
- logging includes many useful things like what URLs are being contacted, etc.

Other modifications:

- completely deprecated the `conf` stuff, replacing all with `os.environ` queries.
- `history_id` as passed on the cli is used in `get_galaxy_connection`, if applicable. I imagine a `None` value there might've been causing issues.