### PR TITLE
Replace docker_port with proxy_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,14 @@ Some environment variables are made available to the user which will allow for c
 
 Variable            | Use
 ------------------- | ---
-`GALAXY_WEB_PORT`   | Port on which Galaxy is running, if applicable
-`NOTEBOOK_PASSWORD` | Password with which to secure the notebook
-`CORS_ORIGIN`       | If the notebook is proxied, this is the URL the end-user will see when trying to access a notebook
-`DOCKER_PORT`       | Used in Galaxy Interactive Environments to ensure that proxy routes are unique and accessible
 `API_KEY`           | Galaxy API Key with which to interface with Galaxy
-`HISTORY_ID`        | ID of current Galaxy History, used in easing the dataset upload/download process
-`REMOTE_HOST`       | Unused
-`GALAXY_URL`        | URL at which Galaxy is accessible
+`CORS_ORIGIN`       | If the notebook is proxied, this is the URL the end-user will see when trying to access a notebook
 `DEBUG`             | Enable debugging mode, mostly for developers
+`GALAXY_URL`        | URL at which Galaxy is accessible
+`GALAXY_WEB_PORT`   | Port on which Galaxy is running, if applicable
+`HISTORY_ID`        | ID of current Galaxy History, used in easing the dataset upload/download process
+`NOTEBOOK_PASSWORD` | Password with which to secure the notebook
+`PROXY_PREFIX`      | Prefix to URL which allows Galaxy proxy to share cookies with Galaxy itself.
 
 
 Authors

--- a/ipython_notebook_config.py
+++ b/ipython_notebook_config.py
@@ -17,12 +17,10 @@ c.NotebookApp.allow_credentials = True
 
 # In case this Notebook was launched from Galaxy a config file exists in /import/
 # For standalone usage we fall back to a port-less URL
-if os.environ.get('DOCKER_PORT', 'none') == 'none':
-    c.NotebookApp.base_url = '/ipython/'
-    c.NotebookApp.webapp_settings = {'static_url_prefix': '/ipython/static/'}
-else:
-    c.NotebookApp.base_url = '/ipython/%s/' % os.environ['DOCKER_PORT']
-    c.NotebookApp.webapp_settings = {'static_url_prefix': '/ipython/%s/static/' % os.environ['DOCKER_PORT']}
+c.NotebookApp.base_url = '%s/ipython/' % os.environ.get('PROXY_PREFIX', '')
+c.NotebookApp.webapp_settings = {
+    'static_url_prefix': '%s/ipython/static/' % os.environ.get('PROXY_PREFIX', '')
+}
 
 if os.environ.get('NOTEBOOK_PASSWORD', 'none') != 'none':
     c.NotebookApp.password = os.environ['NOTEBOOK_PASSWORD']


### PR DESCRIPTION
Here we replace the DOCKER_PORT which had been used to separate users trying to access a given notebook through the proxy, with just relying on the proxy to do it automatically. This simplifies our configuration nicely, and makes the URLs more friendly. Instead of `/ipython/#####/tree` we get `$proxy_prefix/ipython/tree` where `$proxy_prefix` is the completely optional URL prefix.

Here is the [companion PR](https://github.com/galaxyproject/galaxy/pull/790) in Galaxy, and similar code is in branch 15.10 of the rstudio image.
